### PR TITLE
DB-838, DB-843: Handle Intersection character in perl proforma parser

### DIFF
--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -952,6 +952,7 @@ sub write_feature{
        cvname     => 'FlyBase miscellaneous CV',
 	   macro_id   => $unique,
 	   no_lookup  => '1'
+       );
        } else {
        $feature = create_ch_feature(
 	   doc        => $doc,

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -917,17 +917,20 @@ sub write_feature{
         }
       }
       my $gn=$ph{F1a};
+      print STDERR "ERROR: BOB: starting gene value from F1a: $gn\n";
       my @gn_list;
       if($gn=~/[\-XR|\-XP]$/){
       $gn=~s/-XR$//;
       $gn=~s/-XP$//;
 #      $gn=~s/XP$//;
 #      $gn=~s/XR$//;
+      print STDERR "ERROR: BOB: XR/XP condition, now have gene value: $gn\n";
       }
       elsif ($gn=~/[\][P[A-Z|\]R[A-Z]$/){
 #      $gn=~s/-R[A-Z]$//;
       $gn=~s/R[A-Z]$//;
       $gn=~s/P[A-Z]$//;
+      print STDERR "ERROR: BOB: RA/PA condition, now have gene value: $gn\n";
       }
       elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
         print STDERR "ERROR: BOB: gene detection steps identified this as a split system component feature.\n";

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -831,7 +831,7 @@ sub write_feature{
 	   if($type eq 'protein'){
 	       print STDERR "ERROR: Type can not be 'protein', should be 'polypeptide'\n";
 	   }
-     elsif ( !($type ne 'split system combination') && ($ph{F1a} =~ /(INTERSECTION|&cap\;)/ ) ) {
+     elsif ( ($type ne 'split system combination') && ($ph{F1a} =~ /(INTERSECTION|&cap\;)/ ) ) {
        print STDERR "ERROR: split system combination feature $ph{F1a} must have type 'split system combination FBcv:0010025' in F3.\n";
      }
        }

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -947,7 +947,7 @@ sub write_feature{
 	   species    => $species,
 	   genus      => $genus,
 	   type       => $type,
-       cvname     => 'FlyBase miscellaneous CV',
+	   cvname     => 'FlyBase miscellaneous CV',
 	   macro_id   => $unique,
 	   no_lookup  => '1'
        );

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -844,7 +844,7 @@ sub write_feature{
 	    }	      
         }
         if ( $type eq 'split system combination' ) {
-          if( ! $ph{F1a} =~ /&cap\;/ ) {
+          if(!($ph{F1a}=~/&cap\;/)) {
             print STDERR "ERROR: split system combination $ph{F1a} should have '&cap;' "
           }
           ( $unique, $flag ) = get_tempid( 'co', $ph{F1a} );

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -849,6 +849,9 @@ sub write_feature{
           if($ph{F1a}=~/AD.+DBD/) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} should list DBD before AD in its name\n";
           }
+          if($ph{F1a}=~/(XR|XP|R[A-Z]|P[A-Z])$/) {
+            print STDERR "ERROR: new split system combination feature $ph{F1a} must not have any XR/XP/RA/PA suffix in its name\n";
+          }
           ( $unique, $flag ) = get_tempid( 'co', $ph{F1a} );
         } 
         elsif ( $type eq 'polypeptide' ) {

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -890,7 +890,7 @@ sub write_feature{
           $feature = create_ch_feature(
             uniquename => $unique,
             name       => decon( convers( $ph{F1a} ) ),
-            genus      => 'Synthetic',
+            genus      => 'synthetic',
             species    => 'construct',
             type       => $type,
             cvname     => 'FlyBase miscellaneous CV',

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -954,7 +954,7 @@ sub write_feature{
       my $gn_list_length = scalar @gn_list;
       print STDERR "INFO: gene list is this long: $gn_list_length.\n";
       if ( $gn_list_length > 1 ) {
-        print STDERR "INFO: Detected that gene list is > 1.\n";
+        print STDERR "INFO: Detected that gene list is > 1, must be a split system combination feature.\n";
         foreach my $split_component (@gn_list) {
           print STDERR "INFO: split system component $split_component is part of $ph{F1a}\n";
 	      my ($fr,$f_p) = write_feature_relationship( $self->{db}, $doc, 'subject_id',

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -816,7 +816,6 @@ sub write_feature{
 		  #return $out;
     }
 
-   # NEW START
    if( exists( $ph{F1f} ) && $ph{F1f} eq 'new' ){
        if(exists($ph{F2}) && ($ph{F1a} =~/[\-XP|\-XR]$/)){
 	   print STDERR "ERROR: F1a $ph{F1a} cannot end in -XR or -XP if F2 \n";
@@ -918,8 +917,7 @@ sub write_feature{
 	   my ($fr,$f_p) = write_feature_relationship( $self->{db}, $doc, 'subject_id',
                 'object_id', $unique, $gn, 'associated_with', 'unattributed' );
 	   $out.=dom_toString($fr);
-   } # NEW END
-    # EXISTING START
+    }
     elsif( exists( $ph{F1f} ) && $ph{F1f} ne 'new' ){
        ( $genus, $species, $type ) =
               get_feat_ukeys_by_uname( $self->{db}, $ph{F1f} );
@@ -942,7 +940,7 @@ sub write_feature{
 	   print STDERR "ERROR: $unique has been in previous proforma with an action item, separate loading\n";
 	   return ($out,$unique);
        }
-       if($type eq 'split system combination'){
+       if ( $type eq 'split system combination' ) {
        $feature = create_ch_feature(
 	   doc        => $doc,
 	   uniquename => $unique,
@@ -953,7 +951,8 @@ sub write_feature{
 	   macro_id   => $unique,
 	   no_lookup  => '1'
        );
-       } else {
+       }
+       else {
        $feature = create_ch_feature(
 	   doc        => $doc,
 	   uniquename => $unique,
@@ -992,7 +991,7 @@ sub write_feature{
        }
        $fbids{$ph{F1a}}=$unique;
 
-    } # EXISTING END
+    }
 
     $fbids{$ph{F1a}}=$unique;
     $doc->dispose();

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -844,10 +844,12 @@ sub write_feature{
         }
         if ( $type eq 'split system combination' ) {
           if(!($ph{F1a}=~/&cap\;/)) {
-            print STDERR "ERROR: split system combination feature $ph{F1a} should have '&cap;' in its name\n";
+            print STDERR "ERROR: new split system combination feature $ph{F1a} should have '&cap;' in its name\n";
+          }
+          if($ph{F1a}=~/AD.+DBD/) {
+            print STDERR "ERROR: new split system combination feature $ph{F1a} should list DBD before AD in its name\n";
           }
           ( $unique, $flag ) = get_tempid( 'co', $ph{F1a} );
-
         } 
         elsif ( $type eq 'polypeptide' ) {
           if(!($ph{F1a}=~/-XP$/) && !($ph{F1a}=~/]P[A-Z]$/)){

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -814,17 +814,16 @@ sub write_feature{
     my $type;
     my $out = '';
     
-    if(!($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/[\]P[A-Z]|\]R[A-Z]]$/)){
-        print STDERR "ERROR: F1a $ph{F1a} must end with -XR or -XP or ]PA or ]RA\n";
+    if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/[\]P[A-Z]|\]R[A-Z]]$/) && !($ph{F1a} =~/&cap\;/) ) {
+        print STDERR "ERROR: F1a $ph{F1a} must end with -XR, -XP, ]PA, ]RA, or, contain '&cap;' for a split system combination feature\n";
 		  #return $out;
     }
-
    if( exists( $ph{F1f} ) && $ph{F1f} eq 'new' ){
        if(exists($ph{F2}) && ($ph{F1a} =~/[\-XP|\-XR]$/)){
 	   print STDERR "ERROR: F1a $ph{F1a} cannot end in -XR or -XP if F2 \n";
        }
        if(exists($ph{F3})){
-	   my ($t,$SO)=split(/\s+/,$ph{F3});
+     my ($t, $SO) = split(/\s+(SO:|FBcv:)/, $ph{F3});
 	   $type=$t;
 	   if($type eq 'protein'){
 	       print STDERR "ERROR: Type can not be 'protein', should be 'polypeptide'\n";
@@ -858,7 +857,7 @@ sub write_feature{
         }
         else {
           if(!($ph{F1a}=~/-XR$/) && !($ph{F1a}=~/]R[A-Z]$/)){
-            print STDERR "ERROR: transcript $ph{F1a} should be ended with -XR or RA\n";
+            print STDERR "ERROR: transcript $ph{F1a} should be ended with -XR or RA\n";    # BOB
           }
           ( $unique, $flag ) = get_tempid( 'tr', $ph{F1a} );
         }

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -930,7 +930,7 @@ sub write_feature{
       $gn=~s/R[A-Z]$//;
       $gn=~s/P[A-Z]$//;
       }
-      elsif ( $type eq 'split system combination' && ph{F1a} =~ /&cap\;/ ) {
+      elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
         my @gn_list = split('&cap;', @gn_list);
       }
       else {

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -934,7 +934,6 @@ sub write_feature{
         my @gn_list = split('&cap;', @gn_list);
       }
       else {
-        @gn_list = ($ph{F1a});
         print STDERR "ERROR: Can't parse gene for product $ph{F1a}\n";
       }
       my $gn_list_length = scalar @gn_list;

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -917,45 +917,45 @@ sub write_feature{
         }
       }
       my $gn=$ph{F1a};
-      print STDERR "ERROR: BOB: starting gene value from F1a: $gn\n";
+      print STDERR "INFO: starting gene value from F1a: $gn\n";
       my @gn_list;
       if($gn=~/[\-XR|\-XP]$/){
       $gn=~s/-XR$//;
       $gn=~s/-XP$//;
 #      $gn=~s/XP$//;
 #      $gn=~s/XR$//;
-      print STDERR "ERROR: BOB: XR/XP condition, now have gene value: $gn\n";
+      print STDERR "INFO: XR/XP condition, now have gene value: $gn\n";
       }
       # elsif ( $gn =~ /[\][P[A-Z|\]R[A-Z]$/){
         elsif ( $gn =~ /(\])(R|P)[A-Z]$/ ) {
 #      $gn=~s/-R[A-Z]$//;
       $gn=~s/R[A-Z]$//;
       $gn=~s/P[A-Z]$//;
-      print STDERR "ERROR: BOB: RA/PA condition, now have gene value: $gn\n";
+      print STDERR "INFO: RA/PA condition, now have gene value: $gn\n";
       }
       elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
-        print STDERR "ERROR: BOB: gene detection steps identified this as a split system component feature.\n";
+        print STDERR "INFO: split system combination detected.\n";
         @gn_list = split('&cap;', $gn);
         foreach my $i (@gn_list) {
-          print STDERR "ERROR: BOB: Have this SSC allele component: $i\n";
+          print STDERR "INFO: Have this split system combination allele component: $i\n";
         }
       }
       else {
         print STDERR "ERROR: Can't parse gene for product $ph{F1a}\n";
       }
       my $gn_list_length = scalar @gn_list;
-      print STDERR "ERROR: BOB: gene list is this long: $gn_list_length.\n";
+      print STDERR "INFO: gene list is this long: $gn_list_length.\n";
       if ( $gn_list_length > 1 ) {
-        print STDERR "ERROR: BOB: Detected that gene list is > 1.\n";
+        print STDERR "INFO: Detected that gene list is > 1.\n";
         foreach my $split_component (@gn_list) {
-          print STDERR "ERROR: BOB: split system component $split_component is part of $ph{F1a}\n";
+          print STDERR "INFO: split system component $split_component is part of $ph{F1a}\n";
 	      my ($fr,$f_p) = write_feature_relationship( $self->{db}, $doc, 'subject_id',
                           'object_id', $unique, $split_component, 'partially_produced_by', 'unattributed' );
 	      $out.=dom_toString($fr);
         }
       }
       else {
-        print STDERR "gene: $gn HAS PRODUCT: $ph{F1a}\n";
+        print STDERR "INFO: gene: $gn HAS PRODUCT: $ph{F1a}\n";
         ### Write feature_relationship with Gene as partof
         ### Going forward make fr 'associated_with' Aug-03-2011
   	    #$out.=remove_old_gene_link($self->{db},$unique,$gn);

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -818,9 +818,12 @@ sub write_feature{
 		  #return $out;
     }
    if( exists( $ph{F1f} ) && $ph{F1f} eq 'new' ){
-       if(exists($ph{F2}) && ($ph{F1a} =~/[\-XP|\-XR]$/)){
-	   print STDERR "ERROR: F1a $ph{F1a} cannot end in -XR or -XP if F2 \n";
-       }
+      if(exists($ph{F2}) && ($ph{F1a} =~/[\-XP|\-XR]$/)){
+	      print STDERR "ERROR: F1a $ph{F1a} cannot end in -XR or -XP if F2 \n";
+      }
+      elsif ( !(exists($ph{F2})) && !($ph{F1a} =~/[\-XP|\-XR]$/) ) {
+	      print STDERR "ERROR: Require F2 value if F1a $ph{F1a} is transgenic (not -XR or -XP)\n";
+      }
        if(exists($ph{F3})){
      my ($t, $SO) = split(/\s+(SO:|FBcv:)/, $ph{F3});
 	   $type=$t;

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -930,15 +930,21 @@ sub write_feature{
       $gn=~s/P[A-Z]$//;
       }
       elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
+        print STDERR "ERROR: BOB: gene detection steps identified this as a split system component feature.\n";
         my @gn_list = split('&cap;', $gn);
+        foreach my $i (@gn_list) {
+          print STDERR "ERROR: BOB: Have this SSC allele component: $i\n";
+        }
       }
       else {
         print STDERR "ERROR: Can't parse gene for product $ph{F1a}\n";
       }
       my $gn_list_length = scalar @gn_list;
+      print STDERR "ERROR: BOB: gene list is this long: $gn_list_length.\n";
       if ( $gn_list_length > 1 ) {
+        print STDERR "ERROR: BOB: Detected that gene list is > 1.\n";
         foreach my $split_component (@gn_list) {
-          print STDERR "split system component $split_component is part of $ph{F1a}\n";
+          print STDERR "ERROR: BOB: split system component $split_component is part of $ph{F1a}\n";
 	      my ($fr,$f_p) = write_feature_relationship( $self->{db}, $doc, 'subject_id',
                           'object_id', $unique, $split_component, 'partially_produced_by', 'unattributed' );
 	      $out.=dom_toString($fr);

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -813,7 +813,6 @@ sub write_feature{
     my $species='melanogaster';
     my $type;
     my $out = '';
-    # if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/[\]P[A-Z]|\]R[A-Z]]$/) && !($ph{F1a} =~/&cap\;/) ) {    # BILLY - OLD LINE
     if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/(\])(R|P)[A-Z]$/) && !($ph{F1a} =~/&cap\;/) ) {
         print STDERR "ERROR: F1a $ph{F1a} must end with -XR, -XP, ]PA, ]RA, or, contain '&cap;' for a split system combination feature\n";
 		  #return $out;

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -935,7 +935,7 @@ sub write_feature{
       }
       elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
         print STDERR "ERROR: BOB: gene detection steps identified this as a split system component feature.\n";
-        my @gn_list = split('&cap;', $gn);
+        @gn_list = split('&cap;', $gn);
         foreach my $i (@gn_list) {
           print STDERR "ERROR: BOB: Have this SSC allele component: $i\n";
         }

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -857,7 +857,7 @@ sub write_feature{
         }
         else {
           if(!($ph{F1a}=~/-XR$/) && !($ph{F1a}=~/]R[A-Z]$/)){
-            print STDERR "ERROR: transcript $ph{F1a} should be ended with -XR or RA\n";    # BOB
+            print STDERR "ERROR: transcript $ph{F1a} should be ended with -XR or RA\n";
           }
           ( $unique, $flag ) = get_tempid( 'tr', $ph{F1a} );
         }
@@ -890,8 +890,8 @@ sub write_feature{
           $feature = create_ch_feature(
             uniquename => $unique,
             name       => decon( convers( $ph{F1a} ) ),
-            genus      => $genus,
-            species    => $species,
+            genus      => 'Synthetic',
+            species    => 'construct',
             type       => $type,
             cvname     => 'FlyBase miscellaneous CV',
             doc        => $doc,

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -844,10 +844,10 @@ sub write_feature{
         }
         if ( $type eq 'split system combination' ) {
           if(!($ph{F1a}=~/&cap\;/)) {
-            print STDERR "ERROR: new split system combination feature $ph{F1a} should have '&cap;' in its name\n";
+            print STDERR "ERROR: new split system combination feature $ph{F1a} must have '&cap;' in its name\n";
           }
           if($ph{F1a}=~/AD.+DBD/) {
-            print STDERR "ERROR: new split system combination feature $ph{F1a} should list DBD before AD in its name\n";
+            print STDERR "ERROR: new split system combination feature $ph{F1a} must list DBD before AD in its name\n";
           }
           if($ph{F1a}=~/(XR|XP|R[A-Z]|P[A-Z])$/) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} must not have any XR/XP/RA/PA suffix in its name\n";

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -815,7 +815,8 @@ sub write_feature{
         print STDERR "ERROR: F1a $ph{F1a} must end with -XR or -XP or ]PA or ]RA\n";
 		  #return $out;
     }
-    
+
+   # NEW START
    if( exists( $ph{F1f} ) && $ph{F1f} eq 'new' ){
        if(exists($ph{F2}) && ($ph{F1a} =~/[\-XP|\-XR]$/)){
 	   print STDERR "ERROR: F1a $ph{F1a} cannot end in -XR or -XP if F2 \n";
@@ -917,7 +918,8 @@ sub write_feature{
 	   my ($fr,$f_p) = write_feature_relationship( $self->{db}, $doc, 'subject_id',
                 'object_id', $unique, $gn, 'associated_with', 'unattributed' );
 	   $out.=dom_toString($fr);
-   }
+   } # NEW END
+    # EXISTING START
     elsif( exists( $ph{F1f} ) && $ph{F1f} ne 'new' ){
        ( $genus, $species, $type ) =
               get_feat_ukeys_by_uname( $self->{db}, $ph{F1f} );
@@ -940,6 +942,17 @@ sub write_feature{
 	   print STDERR "ERROR: $unique has been in previous proforma with an action item, separate loading\n";
 	   return ($out,$unique);
        }
+       if($type eq 'split system combination'){
+       $feature = create_ch_feature(
+	   doc        => $doc,
+	   uniquename => $unique,
+	   species    => $species,
+	   genus      => $genus,
+	   type       => $type,
+       cvname     => 'FlyBase miscellaneous CV',
+	   macro_id   => $unique,
+	   no_lookup  => '1'
+       } else {
        $feature = create_ch_feature(
 	   doc        => $doc,
 	   uniquename => $unique,
@@ -949,6 +962,7 @@ sub write_feature{
 	   macro_id   => $unique,
 	   no_lookup  => '1'
 	   );
+       }
        if ( exists( $ph{F1d} ) && $ph{F1d} eq 'y' ) {
            print STDERR "Action Items: delete Feature $ph{F1f} == $ph{F1a}\n";
 	   my $op = create_doc_element( $doc, 'is_obsolete', 't' );
@@ -977,8 +991,8 @@ sub write_feature{
        }
        $fbids{$ph{F1a}}=$unique;
 
-    }
-  
+    } # EXISTING END
+
     $fbids{$ph{F1a}}=$unique;
     $doc->dispose();
     return ($out,$unique);

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -926,7 +926,8 @@ sub write_feature{
 #      $gn=~s/XR$//;
       print STDERR "ERROR: BOB: XR/XP condition, now have gene value: $gn\n";
       }
-      elsif ($gn=~/[\][P[A-Z|\]R[A-Z]$/){
+      # elsif ( $gn =~ /[\][P[A-Z|\]R[A-Z]$/){
+        elsif ( $gn =~ /(\])(R|P)[A-Z]$/ ) {
 #      $gn=~s/-R[A-Z]$//;
       $gn=~s/R[A-Z]$//;
       $gn=~s/P[A-Z]$//;
@@ -954,7 +955,7 @@ sub write_feature{
         }
       }
       else {
-        print STDERR "gene $gn product $ph{F1a}\n";
+        print STDERR "gene: $gn HAS PRODUCT: $ph{F1a}\n";
         ### Write feature_relationship with Gene as partof
         ### Going forward make fr 'associated_with' Aug-03-2011
   	    #$out.=remove_old_gene_link($self->{db},$unique,$gn);
@@ -962,7 +963,7 @@ sub write_feature{
                         'object_id', $unique, $gn, 'associated_with', 'unattributed' );
 	    $out.=dom_toString($fr);
       }
-    } # END new bob
+    }
     elsif( exists( $ph{F1f} ) && $ph{F1f} ne 'new' ){
        ( $genus, $species, $type ) =
               get_feat_ukeys_by_uname( $self->{db}, $ph{F1f} );

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -813,8 +813,8 @@ sub write_feature{
     my $species='melanogaster';
     my $type;
     my $out = '';
-    
-    if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/[\]P[A-Z]|\]R[A-Z]]$/) && !($ph{F1a} =~/&cap\;/) ) {
+    # if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/[\]P[A-Z]|\]R[A-Z]]$/) && !($ph{F1a} =~/&cap\;/) ) {    # BILLY - OLD LINE
+    if ( !($ph{F1a} =~/[\-XP|\-XR]$/) && !($ph{F1a} =~/(\])(R|P)[A-Z]$/) && !($ph{F1a} =~/&cap\;/) ) {
         print STDERR "ERROR: F1a $ph{F1a} must end with -XR, -XP, ]PA, ]RA, or, contain '&cap;' for a split system combination feature\n";
 		  #return $out;
     }
@@ -976,6 +976,7 @@ sub write_feature{
 	 }
        if(!exists($ph{F1b})){
 	   ($unique,$genus,$species,$type)=get_feat_ukeys_by_name($self->{db},$ph{F1a}) ;
+    print STDERR "INFO: $ph{F1a} has uniquename $unique\n";
 	   if($unique ne $ph{F1f}){
 	       print STDERR "ERROR: name and uniquename not match $ph{F1f}  $ph{F1a} \n";
 	       exit(0);

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -831,6 +831,9 @@ sub write_feature{
 	   if($type eq 'protein'){
 	       print STDERR "ERROR: Type can not be 'protein', should be 'polypeptide'\n";
 	   }
+     elsif ( !($type ne 'split system combination') && ($ph{F1a} =~ /(INTERSECTION|&cap\;)/ ) ) {
+       print STDERR "ERROR: split system combination feature $ph{F1a} must have type 'split system combination FBcv:0010025' in F3.\n";
+     }
        }
        else{
 	   print STDERR "ERROR: please specify the feature type for the new feature\n";
@@ -855,6 +858,7 @@ sub write_feature{
           if($ph{F1a}=~/(XR|XP|R[A-Z]|P[A-Z])$/) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} must not have any XR/XP/RA/PA suffix in its name\n";
           }
+
           ( $unique, $flag ) = get_tempid( 'co', $ph{F1a} );
         } 
         elsif ( $type eq 'polypeptide' ) {

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -845,7 +845,7 @@ sub write_feature{
         }
         if ( $type eq 'split system combination' ) {
           if(!($ph{F1a}=~/&cap\;/)) {
-            print STDERR "ERROR: split system combination $ph{F1a} should have '&cap;' "
+            print STDERR "ERROR: split system combination feature $ph{F1a} should have '&cap;' in its name\n";
           }
           ( $unique, $flag ) = get_tempid( 'co', $ph{F1a} );
 

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -825,6 +825,7 @@ sub write_feature{
        if(exists($ph{F3})){
      my ($t, $SO) = split(/\s+(SO:|FBcv:)/, $ph{F3});
 	   $type=$t;
+     print STDERR "INFO: new feature has been specified to be of type: $type\n";
 	   if($type eq 'protein'){
 	       print STDERR "ERROR: Type can not be 'protein', should be 'polypeptide'\n";
 	   }
@@ -855,11 +856,14 @@ sub write_feature{
           }
           ( $unique, $flag ) = get_tempid( 'pp', $ph{F1a} );
         }
-        else {
+        elsif ( $type=~/RNA$/ ) {
           if(!($ph{F1a}=~/-XR$/) && !($ph{F1a}=~/]R[A-Z]$/)){
             print STDERR "ERROR: transcript $ph{F1a} should be ended with -XR or RA\n";
           }
           ( $unique, $flag ) = get_tempid( 'tr', $ph{F1a} );
+        }
+        else {
+          print STDERR "ERROR: unexpected F3 value: $type\n";
         }
         if(exists($ph{F1c}) && $ph{F1f} eq 'new' && $unique !~/temp/){
 	print STDERR "ERROR: merge feature should have a FB..:temp id not $unique\n";

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -846,7 +846,7 @@ sub write_feature{
           if(!($ph{F1a}=~/&cap\;/)) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} must have '&cap;' in its name\n";
           }
-          if($ph{F1a}=~/AD.+DBD/) {
+          if(!($ph{F1a}=~/DBD.+AD/)) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} must list DBD before AD in its name\n";
           }
           if($ph{F1a}=~/(XR|XP|R[A-Z]|P[A-Z])$/) {

--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -930,7 +930,7 @@ sub write_feature{
       $gn=~s/P[A-Z]$//;
       }
       elsif ( $type eq 'split system combination' && $ph{F1a} =~ /&cap\;/ ) {
-        my @gn_list = split('&cap;', @gn_list);
+        my @gn_list = split('&cap;', $gn);
       }
       else {
         print STDERR "ERROR: Can't parse gene for product $ph{F1a}\n";

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -4020,6 +4020,22 @@ sub delete_table_relationship {
                 $fbids{ $fr_h{name} } = $uniquename;
             }
         }
+        elsif ( $type eq 'split system combination' ) {
+            $feature = &$create_function(
+                doc        => $doc,
+                uniquename => $uniquename,
+                type       => $type,
+                cvname     => 'FlyBase miscellaneous CV',
+                genus      => $genus,
+                species    => $species,
+                macro_id   => $uniquename
+            );
+            if ( defined($is_obsolete) && $is_obsolete eq 'f' ) {
+                $fbids{ $fr_h{name} } = $uniquename;
+            }
+        }
+
+
         else {
             $feature = &$create_function(
                 doc        => $doc,

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -18676,6 +18676,7 @@ sub toutf {
 
     # $string=~s/\(/\\\(/g;
     # $string=~s/\)/\\\)/g;
+    $string =~ s/&cap\;/\x{2229}/g;    # Intersection character for split-Gal4 combinations.
     $string =~ s/&agr\;/\x{03B1}/g;
     $string =~ s/&Agr\;/\x{0391}/g;
     $string =~ s/&bgr\;/\x{03B2}/g;
@@ -18740,6 +18741,7 @@ sub utftog {
     my ($string) = $_[0];
 
     #print STDERR "string=$string\n";
+    $string =~ s/[\x{2229}]/&cap;/g;    # Intersection character for split-Gal4 combinations
     $string =~ s/[\x{03B1}]/&agr;/g;
     $string =~ s/[\x{0391}]/&Agr;/g;
     $string =~ s/[\x{03B2}]/&bgr;/g;
@@ -18803,6 +18805,7 @@ sub recon {
 
     my ($string) = $_[0];
 
+    $string =~ s/intersection/&cap\;/g;    # Intersection character for split-Gal4 combinations.
     $string =~ s/alpha/&agr\;/g;
     $string =~ s/Alpha/&Agr\;/g;
     $string =~ s/beta/&bgr\;/g;
@@ -18868,6 +18871,7 @@ sub decon {
 
     my $string = $_[0];
 
+    $string =~ s/&cap\;/intersection/g;    # Intersection character for split-Gal4 combinations.
     $string =~ s/&agr\;/alpha/g;
     $string =~ s/&Agr\;/Alpha/g;
     $string =~ s/&bgr\;/beta/g;

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -10932,16 +10932,31 @@ sub merge_records {
             $fbids{$nn} = $unique;
             $out .= feature_name_change_action( $dbh, $doc, $id, $id, $a1, $p );
             if ( $g ne '0' ) {
-                my $feat = create_ch_feature(
-                    doc         => $doc,
-                    uniquename  => $id,
-                    genus       => $g,
-                    species     => $s,
-                    no_lookup   => 1,
-                    type        => $t,
-                    is_obsolete => 't',
-                    macro_id    => $id
-                );
+                if ( $t eq 'split system combination' ) {
+                    my $feat = create_ch_feature(
+                        doc         => $doc,
+                        uniquename  => $id,
+                        genus       => $g,
+                        species     => $s,
+                        no_lookup   => 1,
+                        type        => $t,
+                        cvname     => 'FlyBase miscellaneous CV',
+                        is_obsolete => 't',
+                        macro_id    => $id
+                    );
+                }
+                else {
+                    my $feat = create_ch_feature(
+                        doc         => $doc,
+                        uniquename  => $id,
+                        genus       => $g,
+                        species     => $s,
+                        no_lookup   => 1,
+                        type        => $t,
+                        is_obsolete => 't',
+                        macro_id    => $id
+                    );
+                }
                 $out .= dom_toString($feat);
                 $feat->dispose();
             }

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -18805,7 +18805,7 @@ sub recon {
 
     my ($string) = $_[0];
 
-    $string =~ s/intersection/&cap\;/g;    # Intersection character for split-Gal4 combinations.
+    $string =~ s/INTERSECTION/&cap\;/g;    # Intersection character for split-Gal4 combinations.
     $string =~ s/alpha/&agr\;/g;
     $string =~ s/Alpha/&Agr\;/g;
     $string =~ s/beta/&bgr\;/g;
@@ -18871,7 +18871,7 @@ sub decon {
 
     my $string = $_[0];
 
-    $string =~ s/&cap\;/intersection/g;    # Intersection character for split-Gal4 combinations.
+    $string =~ s/&cap\;/INTERSECTION/g;    # Intersection character for split-Gal4 combinations.
     $string =~ s/&agr\;/alpha/g;
     $string =~ s/&Agr\;/Alpha/g;
     $string =~ s/&bgr\;/beta/g;

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -10944,6 +10944,8 @@ sub merge_records {
                         is_obsolete => 't',
                         macro_id    => $id
                     );
+                    $out .= dom_toString($feat);
+                    $feat->dispose();
                 }
                 else {
                     my $feat = create_ch_feature(
@@ -10956,9 +10958,9 @@ sub merge_records {
                         is_obsolete => 't',
                         macro_id    => $id
                     );
+                    $out .= dom_toString($feat);
+                    $feat->dispose();
                 }
-                $out .= dom_toString($feat);
-                $feat->dispose();
             }
             else {
                 print STDERR

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -265,15 +265,6 @@ sub trim {
     return wantarray ? @s : $s[0];
 }
 
-#sub trim
-#{
-#	my $string = shift;
-#	$string =~ s/^\s+//;
-#	$string =~ s/\s+$//;
-#	return $string;
-#
-#}
-
 sub validate_new_gene_name {
     my $dbh  = shift;
     my $name = shift;


### PR DESCRIPTION
I used this as a reference for how to handle the intersection character.
https://www.compart.com/en/unicode/U+2229

I suggest that curators use `&cap;` when submitting proforma; this will be converted to `intersection` for plain text, and the actual `∩` character where we display the full unicode character set. 