### PR TITLE
Small changes identified based on work for DC-1047)

### DIFF
--- a/lib/perl5/FlyBase/Proforma/Feature.pm
+++ b/lib/perl5/FlyBase/Proforma/Feature.pm
@@ -832,7 +832,7 @@ sub write_feature{
 	       print STDERR "ERROR: Type can not be 'protein', should be 'polypeptide'\n";
 	   }
      elsif ( ($type ne 'split system combination') && ($ph{F1a} =~ /(INTERSECTION|&cap\;)/ ) ) {
-       print STDERR "ERROR: split system combination feature $ph{F1a} must have type 'split system combination FBcv:0010025' in F3.\n";
+       print STDERR "ERROR: split system combination feature $ph{F1a} must have type 'split system combination FBcv:0009026' in F3.\n";
      }
        }
        else{
@@ -853,7 +853,7 @@ sub write_feature{
             print STDERR "ERROR: new split system combination feature $ph{F1a} must have '&cap;' in its name\n";
           }
           if(!($ph{F1a}=~/DBD.+AD/)) {
-            print STDERR "ERROR: new split system combination feature $ph{F1a} must list DBD before AD in its name\n";
+            print STDERR "INFO: new split system combination feature $ph{F1a} must list DBD before AD; cannot detect this using its name (Peeves will have done checks for this so should be OK)\n";
           }
           if($ph{F1a}=~/(XR|XP|R[A-Z]|P[A-Z])$/) {
             print STDERR "ERROR: new split system combination feature $ph{F1a} must not have any XR/XP/RA/PA suffix in its name\n";


### PR DESCRIPTION
I identified two changes based on work on Peeves for DC-1047:

1. corrected FBcv id for 'split system combination' in warning message
2. turned "ERROR" message for combinations that do not match `DBD.+AD` regex to INFO - not all split system components have AD and DBD in their symbols (this is now true for some hemidrivers as there is a new split-inteinGAL4 system that splits in the middle of the DBD, and its also true for other types of split system), so I think having this as an ERROR (which would make the record bounce I think) is too strict.

- Peeves does checks for new symbols using experimental tool info in chado that any DBD is in position 1 and AD is in position 2 and warns if not
-  and it also checks for new symbols (.e.g `allele1&cap;allele2`) that the reverse (i.e. `allele2&&cap;allele1`) is not already in chado and warns if it is

So I think changing it to an INFO will be safe