### PR TITLE
DB-959: in vitro construct changes

### DIFF
--- a/lib/perl5/FlyBase/Proforma/Allele.pm
+++ b/lib/perl5/FlyBase/Proforma/Allele.pm
@@ -331,7 +331,7 @@ sub process {
     }
     if (   defined( $ph{GA8} )
         && $ph{GA8} ne ''
-        && $ph{GA8} =~ /in vitro construct/ )
+        && $ph{GA8} eq 'in vitro construct' )
     {
         $group = 1;
     }

--- a/lib/perl5/FlyBase/Proforma/Util.pm
+++ b/lib/perl5/FlyBase/Proforma/Util.pm
@@ -5069,7 +5069,8 @@ sub check_al_with_fr_or_mutagen {
 		where feature.uniquename='$fb_id' and
 		feature.feature_id=fcv.feature_id and
 		cvterm.cvterm_id=fcv.cvterm_id and
-		cvterm.name like 'in vitro construct%';";
+        cvterm.is_obsolete = 0 and
+		cvterm.name = 'in vitro construct';";
 
         #	print "$state\n";
         my $nmm = $dbh->prepare($state);


### PR DESCRIPTION
These changes increase the parser stringency so that terms like `in vitro construct - X` are not considered.  However, this may be overkill because once the child terms and related annotations are obsoleted, other mechanisms should prevent their use. Also, these changes are not required to handle the parent `in vitro construct` term.

So, it might be safest to not make these changes and leave the parser as is. I want to make sure all reviewers are on board with these changes before merging. Happy to close this PR if there are any objections at all.